### PR TITLE
fix import of resources from jar files

### DIFF
--- a/src/main/com/mucommander/commons/file/AbstractFileClassLoader.java
+++ b/src/main/com/mucommander/commons/file/AbstractFileClassLoader.java
@@ -111,8 +111,9 @@ public class AbstractFileClassLoader extends ClassLoader {
         for (AbstractFile file : files) {
             try {
                 // If the requested resource could be found, returns it.
-                if (file.getChild(name).exists()) {
-                    return file;
+                final AbstractFile child = file.getChild(name);
+                if (child.exists()) {
+                    return child;
                 }
             } catch(IOException ignore) {
                 if (LOGGER != null) {


### PR DESCRIPTION
Currently it is impossible to import custom LookAndFeel jars because the AbstractFileClassLoader tries to load the whole jar as the class file. This results in the error
`java.lang.ClassFormatError: Incompatible magic value 1347093252 in class file`
(the incompatible magic value being the zip file header instead of the 0xcafebabe) and the error is swallowed in ClassFinder at line 102.

This is a fix to load the class from the .class file inside the jar, actually doing what the comment above says rather than returning the parent jar.
