### PR TITLE
Fix Preferences Shortcut Search Filter

### DIFF
--- a/src/main/com/mucommander/ui/dialog/pref/general/ShortcutsPanel.java
+++ b/src/main/com/mucommander/ui/dialog/pref/general/ShortcutsPanel.java
@@ -285,17 +285,9 @@ public class ShortcutsPanel extends PreferencesPanel {
             }
 
    	private void updateFilter(final KeyStroke pressedKeyStroke) {
-        shortcutsTable.updateModel(new ShortcutsTable.ActionFilter() {
-            @Override
-            public boolean accept(String actionId) {
-                KeyStroke accelerator = ActionKeymap.getAccelerator(actionId);
-                KeyStroke alternateAccelerator = ActionKeymap.getAlternateAccelerator(actionId);
-                return pressedKeyStroke.equals(accelerator) || pressedKeyStroke.equals(alternateAccelerator);
-            }
-        });
+        shortcutsTable.updateModel(shortcutsTable.createCurrentAcceleratorsActionFilter(pressedKeyStroke));
     }
 		
-	
 	///////////////////////
     // PrefPanel methods //
     ///////////////////////

--- a/src/main/com/mucommander/ui/dialog/pref/general/ShortcutsTable.java
+++ b/src/main/com/mucommander/ui/dialog/pref/general/ShortcutsTable.java
@@ -244,6 +244,10 @@ public class ShortcutsTable extends PrefTable implements KeyListener, ListSelect
 		data.filter(filter);
 	}
 
+	public ActionFilter createCurrentAcceleratorsActionFilter(KeyStroke accelerator) {
+		return data.new CurrentActionAccceleratorsFilter(accelerator);
+	}
+
 	/**
 	 * Override this method so that calls for SetModel function outside this class
 	 * won't get to setModel(KeymapTableModel model) function.
@@ -314,6 +318,7 @@ public class ShortcutsTable extends PrefTable implements KeyListener, ListSelect
 		public abstract boolean accept(String actionId);
 	}
 	
+
 	/**
 	 * Helper Classes
 	 */
@@ -507,6 +512,24 @@ public class ShortcutsTable extends PrefTable implements KeyListener, ListSelect
 	}
 	
 	private class ShortcutsTableData {
+
+		public class CurrentActionAccceleratorsFilter extends ActionFilter {
+			private KeyStroke accelerator;
+
+			public CurrentActionAccceleratorsFilter(KeyStroke accelerator) {
+				this.accelerator = accelerator;
+			}
+
+			@Override
+			public boolean accept(String actionId) {
+				HashMap<Integer, Object> actionProperties = db.get(actionId);
+				return ShortcutsTableData.this.equals(accelerator,
+				        actionProperties.get(ShortcutsTableData.this.accelerator))
+				        || ShortcutsTableData.this.equals(accelerator,
+				                actionProperties.get(ShortcutsTableData.this.alt_accelerator));
+			}
+		}
+
 		private Object[][] data;
 		private String[] actionIds;
 		private String[] descriptions;


### PR DESCRIPTION
Filter failed to find shortcuts that have been changed but not applied
yet. This fix searches through the current shortcuts in the table
instead of the global preferences.
