### PR TITLE
If bookmark's name is `-` treat it as a separator

### DIFF
--- a/res/runtime/dictionary.properties
+++ b/res/runtime/dictionary.properties
@@ -579,6 +579,7 @@ sortable_list.move_down = Move down
 add_bookmark_dialog.add = Add
 edit_bookmarks_dialog.location = Location
 edit_bookmarks_dialog.new = New
+edit_bookmarks_dialog.is_separator = The specified name defines a separator
 file_viewer.view_error_title = View error
 file_viewer.view_error = Unable to view file.
 file_viewer.file_menu = File

--- a/res/runtime/dictionary_ru_RU.properties
+++ b/res/runtime/dictionary_ru_RU.properties
@@ -547,6 +547,7 @@ sortable_list.move_down = Ниже
 add_bookmark_dialog.add = Добавить
 edit_bookmarks_dialog.new = Новый
 edit_bookmarks_dialog.location = Местоположение
+edit_bookmarks_dialog.is_separator = Указанное имя задает разделитель
 file_viewer.view_error_title = Ошибка при просмотре
 file_viewer.view_error = Невозможно просмотреть файл.
 file_viewer.file_menu = Файл

--- a/src/main/com/mucommander/bookmark/BookmarkManager.java
+++ b/src/main/com/mucommander/bookmark/BookmarkManager.java
@@ -69,6 +69,8 @@ public class BookmarkManager implements VectorChangeListener {
      * stores VectorChangeListener as weak references) */
     private static BookmarkManager singleton = new BookmarkManager();
 
+    /** Value of bookmark's name that make the bookmark treated as a separator */
+    public static final String BOOKMARKS_SEPARATOR = "-";
 
 
     // - Initialisation --------------------------------------------------------

--- a/src/main/com/mucommander/ui/dialog/bookmark/EditBookmarksDialog.java
+++ b/src/main/com/mucommander/ui/dialog/bookmark/EditBookmarksDialog.java
@@ -63,7 +63,11 @@ public class EditBookmarksDialog extends FocusDialog implements ActionListener, 
     private JButton closeButton;
 
     private JTextField nameField;
+    private JLabel locationLabel;
     private JTextField locationField;
+    // separatorNoticePrefix is required to keep the size of the 1st column
+    private JLabel separatorNoticePrefix;
+    private JLabel separatorNoticeLabel;
 
     private AlteredVector<Bookmark> bookmarks;
     private DynamicList<Bookmark> bookmarkList;
@@ -111,8 +115,13 @@ public class EditBookmarksDialog extends FocusDialog implements ActionListener, 
 
         // create a path field with auto-completion capabilities
         this.locationField = new FilePathField();
+        this.locationLabel = new JLabel(Translator.get("location")+":");
         locationField.getDocument().addDocumentListener(this);
-        compPanel.addRow(Translator.get("location")+":", locationField, 10);
+        compPanel.addRow(locationLabel, locationField, 10);
+
+        this.separatorNoticePrefix = new JLabel();
+        this.separatorNoticeLabel = new JLabel(" "+Translator.get("edit_bookmarks_dialog.is_separator"));
+        compPanel.addRow(separatorNoticePrefix, separatorNoticeLabel, 10);
 
         YBoxPanel yPanel = new YBoxPanel(10);
         yPanel.add(compPanel);
@@ -216,6 +225,29 @@ public class EditBookmarksDialog extends FocusDialog implements ActionListener, 
         goToButton.setEnabled(componentsEnabled);
         duplicateButton.setEnabled(componentsEnabled);
         removeButton.setEnabled(componentsEnabled);
+
+        updateSeparatorNoticeVisibility();
+    }
+
+    /**
+     * Updates visibility of `The specified name defines a separator` notice
+     */
+    private void updateSeparatorNoticeVisibility() {
+        String nameFieldValue = nameField.getText();
+        boolean isSeparator = nameFieldValue != null && nameFieldValue.equals(BookmarkManager.BOOKMARKS_SEPARATOR);
+        if (separatorNoticeLabel.isVisible() == isSeparator)
+            return;
+
+        separatorNoticePrefix.setVisible(isSeparator);
+        separatorNoticeLabel.setVisible(isSeparator);
+        if (isSeparator) {
+            // inherit the preferred sizes of locationXXXX controls,
+            // to keep the layout still
+            separatorNoticePrefix.setPreferredSize(locationLabel.getPreferredSize());
+            separatorNoticeLabel.setPreferredSize(locationField.getPreferredSize());
+        }
+        locationLabel.setVisible(!isSeparator);
+        locationField.setVisible(!isSeparator);
     }
 
 
@@ -256,6 +288,8 @@ public class EditBookmarksDialog extends FocusDialog implements ActionListener, 
 
             selectedBookmark.setName(name);
             bookmarkList.itemModified(selectedIndex, false);
+
+            updateSeparatorNoticeVisibility();
         }
         // Update location
         else {

--- a/src/main/com/mucommander/ui/main/DrivePopupButton.java
+++ b/src/main/com/mucommander/ui/main/DrivePopupButton.java
@@ -341,6 +341,11 @@ public class DrivePopupButton extends PopupButton implements BookmarkListener, C
         List<Bookmark> bookmarks = BookmarkManager.getBookmarks();
         if (!bookmarks.isEmpty()) {
             for (Bookmark b : bookmarks) {
+                if (b.getName().equals(BookmarkManager.BOOKMARKS_SEPARATOR) && b.getLocation().isEmpty()) {
+                    popupMenu.add(new JSeparator());
+                    continue;
+                }
+
                 item = popupMenu.add(new CustomOpenLocationAction(mainFrame, b));
                 String location = b.getLocation();
                 if (!location.contains("://")) {

--- a/src/main/com/mucommander/ui/main/DrivePopupButton.java
+++ b/src/main/com/mucommander/ui/main/DrivePopupButton.java
@@ -344,7 +344,7 @@ public class DrivePopupButton extends PopupButton implements BookmarkListener, C
                 item = popupMenu.add(new CustomOpenLocationAction(mainFrame, b));
                 String location = b.getLocation();
                 if (!location.contains("://")) {
-                    AbstractFile file = FileFactory.getFile(b.getLocation());
+                    AbstractFile file = FileFactory.getFile(location);
                     if (file != null) {
                         Image icon = FileIconsCache.getInstance().getImageIcon(file);
                         if (icon != null)

--- a/src/main/com/mucommander/ui/main/DrivePopupButton.java
+++ b/src/main/com/mucommander/ui/main/DrivePopupButton.java
@@ -344,8 +344,12 @@ public class DrivePopupButton extends PopupButton implements BookmarkListener, C
                 item = popupMenu.add(new CustomOpenLocationAction(mainFrame, b));
                 String location = b.getLocation();
                 if (!location.contains("://")) {
-                    Image icon = FileIconsCache.getInstance().getImageIcon(FileFactory.getFile(b.getLocation()));
-                    item.setIcon(new ImageIcon(icon));
+                    AbstractFile file = FileFactory.getFile(b.getLocation());
+                    if (file != null) {
+                        Image icon = FileIconsCache.getInstance().getImageIcon(file);
+                        if (icon != null)
+                            item.setIcon(new ImageIcon(icon));
+                    }
                 } else if (location.startsWith("ftp://") || location.startsWith("sftp://") || location.startsWith("http://")) {
                     item.setIcon(IconManager.getIcon(IconManager.IconSet.FILE, CustomFileIconProvider.NETWORK_ICON_NAME));
                 }


### PR DESCRIPTION
It currently works that way in the main menu (at least for Mac). This commit makes it work in the drive popup either.
Also in bookmarks editor the notice "The specified name defines a separator" is shown if bookmark's name equals to "-"
