### PR TITLE
1) intellij support 2) quotation marks in external commands

### DIFF
--- a/.idea/libraries/apache.xml
+++ b/.idea/libraries/apache.xml
@@ -4,12 +4,13 @@
       <root url="jar://$PROJECT_DIR$/lib/runtime/apache/sanselan-0.97-incubator.jar!/" />
       <root url="jar://$PROJECT_DIR$/lib/runtime/apache/xercesImpl.jar!/" />
       <root url="jar://$PROJECT_DIR$/lib/runtime/apache/hadoop-common-2.5.1.jar!/" />
-      <root url="jar://$PROJECT_DIR$/lib/runtime/apache/commons-collections4-4.0.jar!/" />
       <root url="jar://$PROJECT_DIR$/lib/runtime/apache/commons-net-3.3.jar!/" />
       <root url="jar://$PROJECT_DIR$/lib/runtime/apache/commons-logging-1.1.3.jar!/" />
       <root url="jar://$PROJECT_DIR$/lib/runtime/apache/httpclient-4.3.5.jar!/" />
       <root url="jar://$PROJECT_DIR$/lib/runtime/apache/commons-io-2.4.jar!/" />
       <root url="jar://$PROJECT_DIR$/lib/runtime/apache/commons-codec-1.10.jar!/" />
+      <root url="jar://$PROJECT_DIR$/lib/runtime/apache/commons-collections4-4.1.jar!/" />
+      <root url="jar://$PROJECT_DIR$/lib/runtime/apache/commons-lang-2.6.jar!/" />
     </CLASSES>
     <JAVADOC />
     <SOURCES />

--- a/.idea/libraries/jcifs.xml
+++ b/.idea/libraries/jcifs.xml
@@ -1,7 +1,7 @@
 <component name="libraryTable">
   <library name="jcifs">
     <CLASSES>
-      <root url="jar://$PROJECT_DIR$/lib/runtime/jcifs/jcifs-3.1.14.jar!/" />
+      <root url="jar://$PROJECT_DIR$/lib/runtime/jcifs/jcifs-1.3.18-kohsuke-2-SNAPSHOT.jar!/" />
     </CLASSES>
     <JAVADOC />
     <SOURCES />

--- a/src/main/com/mucommander/process/LocalProcess.java
+++ b/src/main/com/mucommander/process/LocalProcess.java
@@ -66,7 +66,7 @@ public class LocalProcess extends AbstractProcess {
     }
 
     private boolean isQuotedWith(String string, String quotationMark) {
-        return string.startsWith(quotationMark) && string.endsWith(quotationMark)
+        return string.startsWith(quotationMark) && string.endsWith(quotationMark);
     }
 
     private String[] removeOuterQuotationMarks(String[] tokens) {

--- a/src/main/com/mucommander/process/LocalProcess.java
+++ b/src/main/com/mucommander/process/LocalProcess.java
@@ -50,7 +50,7 @@ public class LocalProcess extends AbstractProcess {
      * @throws IOException if the process could not be created.
      */
     public LocalProcess(String[] tokens, File dir) throws IOException {
-        ProcessBuilder pb = new ProcessBuilder(tokens);
+        ProcessBuilder pb = new ProcessBuilder(removeOuterQuotationMarks(tokens));
         // Set the process' working directory
         pb.directory(dir);
         // Merge the process' stdout and stderr
@@ -65,7 +65,21 @@ public class LocalProcess extends AbstractProcess {
             throw new IOException();
     }
 
+    private boolean isQuotedWith(String string, String quotationMark) {
+        return string.startsWith(quotationMark) && string.endsWith(quotationMark)
+    }
 
+    private String[] removeOuterQuotationMarks(String[] tokens) {
+        String[] newTokens = new String[tokens.length];
+        for(int i = 0; i < tokens.length; ++i) {
+            String token = tokens[i];
+            if (token.length() > 1 && isQuotedWith(token, "\"") || isQuotedWith(token, "'")) {
+                token = token.substring(1, token.length() - 1);
+            }
+            newTokens[i]= token;
+        }
+        return newTokens;
+    }
 
     // - Implementation --------------------------------------------------------
     // -------------------------------------------------------------------------

--- a/src/mucommander.iml
+++ b/src/mucommander.iml
@@ -23,7 +23,6 @@
     <orderEntry type="library" name="batik" level="project" />
     <orderEntry type="library" name="jets3t" level="project" />
     <orderEntry type="library" name="vim25" level="project" />
-    <orderEntry type="library" name="j2ssh" level="project" />
     <orderEntry type="library" name="jcifs" level="project" />
     <orderEntry type="library" name="jna" level="project" />
     <orderEntry type="library" name="junrar" level="project" />
@@ -31,6 +30,8 @@
     <orderEntry type="library" name="testng" level="project" />
     <orderEntry type="library" name="jediterm" level="project" />
     <orderEntry type="library" name="quaqua" level="project" />
-    <orderEntry type="library" name="java-iso-tools" level="project" />
+    <orderEntry type="library" name="j2ssh-maverick-1.5.5" level="project" />
+    <orderEntry type="library" name="iso9660-writer-2.0.0" level="project" />
+    <orderEntry type="library" name="sabre-2.0.0" level="project" />
   </component>
 </module>


### PR DESCRIPTION
1) fixed: intellij idea: resolve broken paths for dependencies. Now we can build and debug trolCommander in IntelliJ Idea.

2) added: external command: it is possible now to enclose executable path in quotation marks like this: "/Applications/Sublime Text.app/Contents/SharedSupport/bin/subl" $f